### PR TITLE
Add S3 bucket for sccache

### DIFF
--- a/autoscalers.tf
+++ b/autoscalers.tf
@@ -4,6 +4,57 @@ locals {
   ]
 }
 
+resource "aws_iam_role" "autoscalers" {
+  name = "autoscalers_role"
+
+  # Terraform's "jsonencode" function converts a
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "autoscalers" {
+  name = "describeTags"
+  role = aws_iam_role.autoscalers.id
+
+
+  policy = <<-EOF
+ {
+   "Version": "2012-10-17",
+   "Statement": [
+     {
+       "Sid": "SccacheAccess",
+       "Effect": "Allow",
+       "Action": [
+         "s3:DeleteObject",
+         "s3:GetObject",
+         "s3:ListBucket",
+         "s3:PutObject"
+       ],
+       "Resource": "arn:aws:s3:::tvm-sccache-${var.environment}/*"
+     }
+   ]
+ }
+EOF
+}
+
+resource "aws_iam_instance_profile" "autoscalers" {
+  name = "autoscalers_instance_profile"
+  role = aws_iam_role.autoscalers.name
+}
+
 module "Jenkins-Autoscalers" {
   for_each                 = var.autoscaler_types
   source                   = "./modules/autoscaler"
@@ -13,6 +64,7 @@ module "Jenkins-Autoscalers" {
   image_family             = each.value.image_family
   agent_instance_type      = each.value.agent_instance_type
   jenkins_pub_key          = var.jenkins_pub_key
+  jenkins_instance_profile = aws_iam_instance_profile.autoscalers.name
   executor_access_pub_keys = var.executor_access_pub_keys
   min_size                 = each.value.min_size
   max_size                 = each.value.max_size

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,10 @@ locals {
 }
 
 terraform {
+  required_providers {
+    aws  = "~> 3.73.0"
+  }
+
   backend "s3" {
     bucket = "tvm-ci-terraform-state"
     key    = "tfstate"

--- a/modules/autoscaler/main.tf
+++ b/modules/autoscaler/main.tf
@@ -36,6 +36,9 @@ resource "aws_launch_template" "autoscaler" {
       volume_size = 250
     }
   }
+  iam_instance_profile {
+    name = var.jenkins_instance_profile
+  }
   vpc_security_group_ids = var.security_groups
   instance_type          = var.agent_instance_type
 }

--- a/modules/autoscaler/variables.tf
+++ b/modules/autoscaler/variables.tf
@@ -37,3 +37,7 @@ variable "min_size" {
 variable "max_size" {
   type = number
 }
+
+variable "jenkins_instance_profile" {
+  type = string
+}

--- a/persistent_agents.tf
+++ b/persistent_agents.tf
@@ -32,14 +32,15 @@ resource "aws_iam_role_policy" "persistent_agents" {
    "Version": "2012-10-17",
    "Statement": [
      {
-       "Sid": "DescribeTags",
+       "Sid": "SccacheAccess",
        "Effect": "Allow",
        "Action": [
-         "ec2:DescribeTags"
+         "s3:DeleteObject",
+         "s3:GetObject",
+         "s3:ListBucket",
+         "s3:PutObject"
        ],
-      "Resource": [
-        "*"
-      ]
+       "Resource": "arn:aws:s3:::tvm-sccache-${var.environment}/*"
      }
    ]
  }

--- a/sccache.tf
+++ b/sccache.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "bucket" {
+  bucket = "tvm-sccache-${var.environment}"
+  acl    = "private"
+
+  tags = {
+    Name = "tvm-sccache-${var.environment}"
+  }
+}


### PR DESCRIPTION
This adds an S3 bucket with access via IAM for both the autoscalers and persistent agents. Needed for [apache#10246
](https://github.com/apache/tvm/pull/10246)

cc @areusch @konturn 