### PR TITLE
Bump autoscaled GPU instance max from 15 -> 30

### DIFF
--- a/vars/tvm-ci-prod.auto.tfvars
+++ b/vars/tvm-ci-prod.auto.tfvars
@@ -97,7 +97,7 @@ autoscaler_types = {
     agent_instance_type = "g4dn.xlarge"
     labels              = "TensorCore GPU Linux GPU-DOCKER GPUBUILD"
     min_size            = 0
-    max_size            = 15
+    max_size            = 30
   }
   "Prod-Autoscaler-Jenkins-ARM" = {
     image_family        = "jenkins-stock-agent-arm"


### PR DESCRIPTION
After removing persistent GPU nodes CI capacity is pretty reduced, we need to increase autoscaling limits to match old capacity.
