### PR TITLE
Revert "Enable no delay provisioning"

### DIFF
--- a/templates/fleet_config.yaml.tpl
+++ b/templates/fleet_config.yaml.tpl
@@ -24,7 +24,7 @@ jenkins:
       maxTotalUses: -1
       minSize: ${attributes.min_size}
       name: "${name}"
-      noDelayProvision: true
+      noDelayProvision: false
       numExecutors: 1
       oldId: "803939ae-c6f8-4c7a-8386-0d1a9af631ad"
       privateIpUsed: true


### PR DESCRIPTION
As indicated [here](https://github.com/jenkinsci/ec2-fleet-plugin/issues/177), the fleet autoscaler struggles scaling down when using the 'no delay provisioning' option. We had this issue last night where nodes were not scaling down, and as soon as I disabled the option manually for our fleets all nodes scaled down as desired. cc @driazati @areusch 