### PR TITLE
fix: restrict node usage to matching labels

### DIFF
--- a/modules/head-node/templates/fleet_config.yaml.tpl
+++ b/modules/head-node/templates/fleet_config.yaml.tpl
@@ -29,7 +29,7 @@ jenkins:
         oldId: "803939ae-c6f8-4c7a-8386-0d1a9af631ad"
         privateIpUsed: false
         region: "us-west-2"
-        restrictUsage: false
+        restrictUsage: true
         scaleExecutorsByWeight: false
   
   %{~ endfor ~}

--- a/templates/fleet_config.yaml.tpl
+++ b/templates/fleet_config.yaml.tpl
@@ -29,7 +29,7 @@ jenkins:
       oldId: "803939ae-c6f8-4c7a-8386-0d1a9af631ad"
       privateIpUsed: true
       region: "us-west-2"
-      restrictUsage: false
+      restrictUsage: true
       scaleExecutorsByWeight: false
   
   %{~ endfor ~}


### PR DESCRIPTION
Node usage is not restricted to jobs with matching labels. This might
cause a job failure due to running on an incorrect node. Update the
configuration to restrict usage to jobs with matching label expressions
only.