### PR TITLE
Create ECR repos for CI images

### DIFF
--- a/autoscalers.tf
+++ b/autoscalers.tf
@@ -34,17 +34,44 @@ resource "aws_iam_role_policy" "autoscalers" {
  {
    "Version": "2012-10-17",
    "Statement": [
-     {
-       "Sid": "SccacheAccess",
-       "Effect": "Allow",
-       "Action": [
+      {
+        "Sid": "SccacheAccess",
+        "Effect": "Allow",
+        "Action": [
          "s3:DeleteObject",
          "s3:GetObject",
          "s3:ListBucket",
          "s3:PutObject"
-       ],
-       "Resource": "arn:aws:s3:::tvm-sccache-${var.environment}/*"
-     }
+        ],
+        "Resource": "arn:aws:s3:::tvm-sccache-${var.environment}/*"
+      },
+      {
+          "Sid": "ECRAccess1",
+          "Effect": "Allow",
+          "Action": [
+              "ecr:BatchCheckLayerAvailability",
+              "ecr:BatchGetImage",
+              "ecr:CompleteLayerUpload",
+              "ecr:DescribeImages",
+              "ecr:DescribeRepositories",
+              "ecr:GetDownloadUrlForLayer",
+              "ecr:InitiateLayerUpload",
+              "ecr:ListImages",
+              "ecr:PutImage",
+              "ecr:TagResource",
+              "ecr:UploadLayerPart"
+          ],
+          "Resource": "arn:aws:ecr:us-west-2:*"
+      },
+      {
+          "Sid": "ECRAccess2",
+          "Effect": "Allow",
+          "Action": [
+              "ecr:DescribeRegistry",
+              "ecr:GetAuthorizationToken"
+          ],
+          "Resource": "*"
+      }
    ]
  }
 EOF

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,34 @@
+resource "aws_ecr_repository" "ci_ecr" {
+  count                = "${length(var.ecr_repositories)}"
+  name                 = "${var.ecr_repositories[count.index]}"
+  image_tag_mutability = "IMMUTABLE"
+}
+
+resource "aws_ecr_lifecycle_policy" "untagged_removal_policy" {
+  count      = "${length(var.ecr_repositories)}"
+  depends_on = [ "aws_ecr_repository.ci_ecr" ]
+  repository = "${aws_ecr_repository.ci_ecr[count.index].name}"
+
+  policy = <<EOF
+{
+    "rules": [
+        {
+        "action": {
+            "type": "expire"
+        },
+        "selection": {
+            "countType": "sinceImagePushed",
+            "countUnit": "days",
+            "countNumber": 1,
+            "tagStatus": "tagged",
+            "tagPrefixList": [
+            "PR-"
+            ]
+        },
+        "description": "Remove PR images",
+        "rulePriority": 1
+        }
+    ]
+}
+EOF
+}

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,11 @@ variable "subject_alternative_names" {
   default = []
 }
 
+variable "ecr_repositories" {
+  type    = list(string)
+  default = []
+}
+
 variable "is_private" {
   type    = bool
   default = false

--- a/vars/tvm-ci-prod.auto.tfvars
+++ b/vars/tvm-ci-prod.auto.tfvars
@@ -49,6 +49,17 @@ autoscaler_types = {
   }
 }
 
+ecr_repositories = [
+  "ci_arm",
+  "ci_cpu",
+  "ci_gpu",
+  "ci_hexagon",
+  "ci_i386",
+  "ci_lint",
+  "ci_qemu",
+  "ci_wasm"
+]
+
 domain_name               = "ci.tlcpack.ai"
 subject_alternative_names = ["docs.staging.tlcpack.ai"]
 ebs_volume_size           = 500


### PR DESCRIPTION
This adds some repositories to enable https://github.com/apache/tvm/issues/10646. The main caveat with this approach (vs letting CI nodes create the repositories as necessary) is that new images require an interaction with the infra team, but this is probably fine since these are pretty rare (`ci_hexagon` is the only new one in the past several months).


cc @areusch 