### PR TITLE
Revert "Revert "Enable no delay provisioning""

### DIFF
--- a/templates/fleet_config.yaml.tpl
+++ b/templates/fleet_config.yaml.tpl
@@ -24,7 +24,7 @@ jenkins:
       maxTotalUses: -1
       minSize: ${attributes.min_size}
       name: "${name}"
-      noDelayProvision: false
+      noDelayProvision: true
       numExecutors: 1
       oldId: "803939ae-c6f8-4c7a-8386-0d1a9af631ad"
       privateIpUsed: true


### PR DESCRIPTION
This reverts commit f0d4ca76796cee84c343fa5afd1a71328db7576c.

The problem with scaling down may go away if the flag is flipped only on a full Jenkins restart, so try that here. We will have to monitor the nodes and revert again if there are still problems scaling down.
