### PR TITLE
Reduce idle wait from 30m to 5m

### DIFF
--- a/templates/fleet_config.yaml.tpl
+++ b/templates/fleet_config.yaml.tpl
@@ -16,7 +16,7 @@ jenkins:
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
       disableTaskResubmit: false
       fleet: ${name}
-      idleMinutes: 30
+      idleMinutes: 5
       initOnlineCheckIntervalSec: 15
       initOnlineTimeoutSec: 180
       labelString: "${attributes.labels}"


### PR DESCRIPTION
Spinning up a node is not very expensive (1-2 minutes) so we shouldn't keep nodes around unless we have lots of work for them to do

cc @areusch
