### PR TITLE
Consolidate node names

### DIFF
--- a/vars/tvm-ci-prod.auto.tfvars
+++ b/vars/tvm-ci-prod.auto.tfvars
@@ -29,14 +29,14 @@ autoscaler_types = {
   "Prod-Autoscaler-Jenkins-CPU" = {
     image_family        = "jenkins-stock-agent"
     agent_instance_type = "c4.4xlarge"
-    labels              = "CPU CPU-DOCKER CPU-docker-build"
+    labels              = "CPU"
     min_size            = 0
     max_size            = 90
   }
   "Prod-Autoscaler-Jenkins-GPU" = {
     image_family        = "jenkins-gpu-agent"
     agent_instance_type = "g4dn.xlarge"
-    labels              = "TensorCore GPU Linux GPU-DOCKER GPUBUILD"
+    labels              = "GPU"
     min_size            = 0
     max_size            = 90
   }


### PR DESCRIPTION
This removes the suffixes from the CPU and GPU node names since they
aren't different nodes any more

cc @areusch @konturn 