### PR TITLE
feat: update ecr syntax to use for_each meta-arg

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -1,13 +1,12 @@
 resource "aws_ecr_repository" "ci_ecr" {
-  count                = "${length(var.ecr_repositories)}"
-  name                 = "${var.ecr_repositories[count.index]}"
+  for_each                = toset(var.ecr_repositories)
+  name                 = each.value
   image_tag_mutability = "IMMUTABLE"
 }
 
 resource "aws_ecr_lifecycle_policy" "untagged_removal_policy" {
-  count      = "${length(var.ecr_repositories)}"
-  depends_on = [ "aws_ecr_repository.ci_ecr" ]
-  repository = "${aws_ecr_repository.ci_ecr[count.index].name}"
+  for_each      = toset(var.ecr_repositories)
+  repository = aws_ecr_repository.ci_ecr[each.value].name
 
   policy = <<EOF
 {


### PR DESCRIPTION
cc @driazati 
While `count` works here, `for_each` is preferred for two reasons:
1. It operates on sets, so duplicate entries are merged together
2. Order doesn't matter

The second one is especially important, since it means that if you added an entry to the middle of the `ecr_repositories` list, Terraform would _delete_ all following entries and recreate them, since the index for those entries will have changed.