### PR TITLE
Add CPU-SMALL instances

### DIFF
--- a/vars/tvm-ci-prod.auto.tfvars
+++ b/vars/tvm-ci-prod.auto.tfvars
@@ -35,6 +35,13 @@ autoscaler_types = {
     on_demand_percentage_above_base_capacity = 50
     on_demand_base_capacity = 6
   }
+  "Prod-Autoscaler-Jenkins-CPU-Small" = {
+    image_family        = "jenkins-stock-agent"
+    agent_instance_type = "r5.large"
+    labels              = "CPU-SMALL"
+    min_size            = 0
+    max_size            = 45
+  }
   "Prod-Autoscaler-Jenkins-GPU" = {
     image_family        = "jenkins-gpu-agent"
     agent_instance_type = "g4dn.xlarge"


### PR DESCRIPTION
This adds a class of CPU instances that are far [cheaper](https://instances.vantage.sh/?compare_on=true&selected=c4.4xlarge,r5.large) than the current `CPU` instances that we can use for certain tasks that don't require big instances, I'm thinking for linting and builds (since those are mostly cached anyways). We could also potentially move certain test steps to these instances such as the unit tests but reliability.

cc @areusch @konturn 