### PR TITLE
fix: update hashes of terraform actions

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main'
-        uses: dflook/terraform-apply@1842b14da5fa3f42aefbe2c13ce82418c78b01b0
+        uses: dflook/terraform-apply@ce70027700f2c6b17bcaf421b6e4e9b5e62b7bff #v1.22.2
         with:
           var_file: |
             vars/tvm-ci-prod.auto.tfvars

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Terraform fmt
         id: fmt
-        uses: dflook/terraform-fmt@1842b14da5fa3f42aefbe2c13ce82418c78b01b0
+        uses: dflook/terraform-fmt@976b15307d109bc95a5c0518fd79b9182c17e095 #v1.22.2
         continue-on-error: true
       - name: Terraform Validate
         id: validate
-        uses: dflook/terraform-validate@1842b14da5fa3f42aefbe2c13ce82418c78b01b0
+        uses: dflook/terraform-validate@004cb11294aa51f17cddfeda079592a1ae621dc8 #v1.22.2
       - name: Terraform Plan
-        uses: dflook/terraform-plan@1842b14da5fa3f42aefbe2c13ce82418c78b01b0
+        uses: dflook/terraform-plan@1547271e3127df7ad5b667eeed17e8e3a77a76a0 #v1.22.2
         id: plan
         with:
           var_file: |


### PR DESCRIPTION
cc @areusch @Mousius apparently, the hashes of the actions which are published for each tag differ from the tag's corresponding SHA. I inferred these SHA's by running pipelines on my fork (pinning the actions by tag) and observing the SHA's that are actually used. Surely there's a better way to do this, but it shouldn't matter until we decide to update the Actions sometime in the (probably distant) future.