### PR TITLE
Add ARM-SMALL instance type

### DIFF
--- a/vars/tvm-ci-prod.auto.tfvars
+++ b/vars/tvm-ci-prod.auto.tfvars
@@ -74,6 +74,15 @@ autoscaler_types = {
     on_demand_percentage_above_base_capacity = 100
     on_demand_base_capacity                  = 0
   }
+  "Prod-Autoscaler-Jenkins-ARM-Small" = {
+    image_family                             = "jenkins-stock-agent-arm"
+    agent_instance_type                      = "r6g.large"
+    labels                                   = "ARM-SMALL"
+    min_size                                 = 0
+    max_size                                 = 90
+    on_demand_percentage_above_base_capacity = 100
+    on_demand_base_capacity                  = 0
+  }
 }
 
 ecr_repositories = [


### PR DESCRIPTION
Same as in #24 this adds `r6g.large` instances under the
`ARM-SMALL` label so we can start testing and using those in CI (5x
cheaper than `m6g.4xlarge`). If that works well we can convert some
usages over, and if not we can remove this autoscaling group.

cc @konturn @areusch 