### PR TITLE
Add S3 bucket for CI artifacts

### DIFF
--- a/artifacts.tf
+++ b/artifacts.tf
@@ -1,0 +1,17 @@
+resource "aws_s3_bucket" "artifacts-bucket" {
+  bucket = "jenkins-artifacts-${var.environment}"
+  acl    = "private"
+
+  tags = {
+    Name = "jenkins-artifacts-${var.environment}"
+  }
+
+  lifecycle_rule {
+    id      = "weekly_retention"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
+}

--- a/artifacts.tf
+++ b/artifacts.tf
@@ -1,9 +1,9 @@
 resource "aws_s3_bucket" "artifacts-bucket" {
-  bucket = "jenkins-artifacts-${var.environment}"
+  bucket = "tvm-jenkins-artifacts-${var.environment}"
   acl    = "private"
 
   tags = {
-    Name = "jenkins-artifacts-${var.environment}"
+    Name = "tvm-jenkins-artifacts-${var.environment}"
   }
 
   lifecycle_rule {

--- a/autoscalers.tf
+++ b/autoscalers.tf
@@ -46,6 +46,17 @@ resource "aws_iam_role_policy" "autoscalers" {
         "Resource": "arn:aws:s3:::tvm-sccache-${var.environment}/*"
       },
       {
+        "Sid": "ArtifactsAccess",
+        "Effect": "Allow",
+        "Action": [
+         "s3:DeleteObject",
+         "s3:GetObject",
+         "s3:ListBucket",
+         "s3:PutObject"
+        ],
+        "Resource": "arn:aws:s3:::jenkins-artifacts-${var.environment}/*"
+      },
+      {
           "Sid": "ECRAccess1",
           "Effect": "Allow",
           "Action": [


### PR DESCRIPTION
This adds a bucket which would be used by CI builds to store
intermediate artifacts rather than Jenkins' built in `stash` and
`unstash` directives. Those take a lot of time on some occasions (20~ish
minutes) and slow down the Jenkins head node (since it has to do the
actual storing of data).

The counterpart in apache/tvm would replace `stash` with a function to
store data in S3 instead.

cc @areusch @konturn 