### PR TITLE
Add sccache buckets for MacOS / Windows

### DIFF
--- a/sccache.tf
+++ b/sccache.tf
@@ -6,3 +6,21 @@ resource "aws_s3_bucket" "bucket" {
     Name = "tvm-sccache-${var.environment}"
   }
 }
+
+resource "aws_s3_bucket" "bucket-windows" {
+  bucket = "tvm-sccache-windows-${var.environment}"
+  acl    = "public-read"
+
+  tags = {
+    Name = "tvm-sccache-windows-${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket" "bucket-macos" {
+  bucket = "tvm-sccache-macos-${var.environment}"
+  acl    = "public-read"
+
+  tags = {
+    Name = "tvm-sccache-macos-${var.environment}"
+  }
+}


### PR DESCRIPTION
This adds S3 buckets so we can set up sccache for GitHub Actions. Unlike
Jenkins where we can configure the bucket to be accessible from CI
nodes, most TVM PR Actions jobs have no way of accessing a bucket (jobs
from forked PRs aren't allowed access to secrets). The solution here is
to host a bucket per OS that is publicly readable. This will be used
from PRs to accelerate builds. It will be filled with cached data from
jobs on `main` and branches (which will have write access via a secret
id/key pair).
