### PR TITLE
Shuffle parameters for autoscaled nodes

### DIFF
--- a/modules/autoscaler/main.tf
+++ b/modules/autoscaler/main.tf
@@ -33,7 +33,7 @@ resource "aws_launch_template" "autoscaler" {
   block_device_mappings {
     device_name = "/dev/sda1"
     ebs {
-      volume_size = 250
+      volume_size = 80
     }
   }
   iam_instance_profile {

--- a/templates/fleet_config.yaml.tpl
+++ b/templates/fleet_config.yaml.tpl
@@ -16,7 +16,7 @@ jenkins:
           sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
       disableTaskResubmit: false
       fleet: ${name}
-      idleMinutes: 5
+      idleMinutes: 1
       initOnlineCheckIntervalSec: 15
       initOnlineTimeoutSec: 180
       labelString: "${attributes.labels}"

--- a/vars/tvm-ci-prod.auto.tfvars
+++ b/vars/tvm-ci-prod.auto.tfvars
@@ -43,7 +43,7 @@ autoscaler_types = {
     agent_instance_type                      = "r5.large"
     labels                                   = "CPU-SMALL"
     min_size                                 = 0
-    max_size                                 = 100
+    max_size                                 = 200
     on_demand_percentage_above_base_capacity = 100
     on_demand_base_capacity                  = 0
   }


### PR DESCRIPTION
These couple changes should help get the job queue under control now
that we're using a lot more node-level parallelism. EBS costs are also up since every node is getting 250 GB which is more than it needs (spot checked a bunch of nodes, never saw more than 65 GB in use). Queue got pretty backed up yesterday

![image](https://user-images.githubusercontent.com/9407960/170364243-17e8335b-19b9-4d7a-9bf7-24149201f5a7.png)

