### PR TITLE
Bump EBS size to 150GB

### DIFF
--- a/modules/autoscaler/main.tf
+++ b/modules/autoscaler/main.tf
@@ -33,7 +33,7 @@ resource "aws_launch_template" "autoscaler" {
   block_device_mappings {
     device_name = "/dev/sda1"
     ebs {
-      volume_size = 80
+      volume_size = 150
     }
   }
   iam_instance_profile {


### PR DESCRIPTION
This was reduced too much in #40 so there are failures popping up like
in
https://ci.tlcpack.ai/blue/organizations/jenkins/tvm/detail/PR-11450/3/pipeline#step-178-log-339.
We could investigate what's taking up the space but for now we should
just back this off.